### PR TITLE
Sort API and Examples docs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -422,7 +422,11 @@ module.exports = function(grunt) {
     var accum = [];
 
     // refers to grunt-local "egPrograms"
-    egPrograms.forEach(function(egProgram) {
+    egPrograms.sort(function (a,b) {
+      if (a.topic < b.topic) return -1;
+      if (a.topic > b.topic) return 1;
+      return 0;
+    }).forEach(function(egProgram) {
 
       accum.push("### " + egProgram.topic);
 
@@ -535,6 +539,10 @@ module.exports = function(grunt) {
         target: "api/" + title.toLowerCase() + "/index.html",
         pretty: "api/" + title.toLowerCase() + "/"
       };
+    }).sort(function (a,b) {
+      if (a.title < b.title) return -1;
+      if (a.title > b.title) return 1;
+      return 0;
     });
 
     var list = markdown.render(matches.reduce(function(accum, match) {


### PR DESCRIPTION
API docs are already kept pretty well alphabetical in the Wiki, but this enforces it. Examples on the other hand are not sorted at all, this should make it a little easier to find things.